### PR TITLE
ITPL-11947: Removing stat tracking from seneca

### DIFF
--- a/seneca.js
+++ b/seneca.js
@@ -1363,7 +1363,6 @@ function make_seneca( initial_options ) {
     var act_done = function(err) {
       try {
         var actend = Date.now()
-        private$.timestats.point( actend-actstart, actmeta.argpattern )
 
         prior_ctxt.depth--
         prior_ctxt.entry = prior_ctxt.depth <= 0


### PR DESCRIPTION
#### Original Issue
- Seneca was keeping track of all action patterns and how their execution time. This was not being cleaned up even after hours of inactivity and multiple garbage collections.

#### Changes Proposed
- Taking out metrics tracking for now. In another patch we can re-introduce this functionality, but being disabled by default, as tracking the metrics might actually be interesting to see what parts of our app are called the most/take the longest